### PR TITLE
Fix DatasetMeta stub logic

### DIFF
--- a/src/lightning_ml/core/dataset.py
+++ b/src/lightning_ml/core/dataset.py
@@ -57,9 +57,10 @@ class DatasetMeta(ABCMeta):
         if keys:
             for key in keys:
                 method_name = f"get_{key}"
-                if method_name not in namespace:
+                if method_name not in namespace and not any(
+                    hasattr(base, method_name) for base in bases
+                ):
                     # define an abstractmethod stub
-                    # define a stub that just raises NotImplementedError
                     def _stub(self, idx: int, _method_name=method_name):
                         raise NotImplementedError(
                             f"{name} must implement `{_method_name}`"

--- a/tests/test_numpy_dataset.py
+++ b/tests/test_numpy_dataset.py
@@ -1,0 +1,49 @@
+import sys
+import types
+import importlib.util
+import pathlib
+
+BASE = pathlib.Path('src/lightning_ml')
+
+# Helper to load module by path without executing package __init__
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_numpy_labelled_dataset_instantiation():
+    # Stub minimal dependencies
+    torch = types.ModuleType('torch')
+    torch.Tensor = object
+    torch.nn = types.ModuleType('nn'); torch.nn.Module = object
+    torch.utils = types.ModuleType('utils'); torch.utils.data = types.ModuleType('data'); torch.utils.data.Dataset = object
+    sys.modules['torch'] = torch
+    sys.modules['torch.nn'] = torch.nn
+    sys.modules['torch.utils'] = torch.utils
+    sys.modules['torch.utils.data'] = torch.utils.data
+
+    pl = types.ModuleType('pytorch_lightning')
+    pl.LightningModule = type('LightningModule', (), {})
+    sys.modules['pytorch_lightning'] = pl
+
+    sys.modules['pandas'] = types.ModuleType('pandas')
+    PIL = types.ModuleType('PIL'); PIL_Image = types.ModuleType('PIL.Image')
+    sys.modules['PIL'] = PIL; sys.modules['PIL.Image'] = PIL_Image
+
+    # Load modules manually
+    core_dataset = _load('lightning_ml.core.dataset', BASE / 'core/dataset.py')
+    core_pkg = types.ModuleType('lightning_ml.core')
+    core_pkg.BaseDataset = core_dataset.BaseDataset
+    sys.modules['lightning_ml.core'] = core_pkg
+
+    _load('lightning_ml.datasets.abstract', BASE / 'datasets/abstract.py')
+    _load('lightning_ml.datasets.unlabelled', BASE / 'datasets/unlabelled.py')
+    _load('lightning_ml.datasets.labelled', BASE / 'datasets/labelled.py')
+    common = _load('lightning_ml.datasets.common', BASE / 'datasets/common.py')
+
+    ds = common.NumpyLabelledDataset([1, 2], [3, 4])
+    assert len(ds) == 2
+


### PR DESCRIPTION
## Summary
- ensure DatasetMeta only injects stubs when no base class defines the method
- add regression test for NumpyLabelledDataset instantiation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481c43d350832dafd99ec2d5557203