### PR TITLE
Refactor splitters using mixins

### DIFF
--- a/src/lightning_ml/utils/data/splitters/__init__.py
+++ b/src/lightning_ml/utils/data/splitters/__init__.py
@@ -1,48 +1,19 @@
 from ...registry import Registry
+
 DATA_SPLITTER_REGISTRY = Registry('DataSplitter')
 
 from .base_splitter import DataSplitter
-from .holdout_splitter import HoldoutSplitter
+from .holdout_splitter import RandomSplitter
 from .stratified_splitter import StratifiedSplitter
 from .kfold_splitter import KFoldSplitter
 from .stratified_kfold_splitter import StratifiedKFoldSplitter
 
+
 def _data_splitter_factory(config: dict) -> DataSplitter:
-    """Returns CompositeLoss object
-
-    Args:
-        config (dict): _description_
-
-    Returns:
-        dict: _description_
-    """
+    """Instantiate a splitter from a config dictionary."""
     splitter = DATA_SPLITTER_REGISTRY.get(
-        config['DATASET']['split_method']['name'])(
-            **config['DATASET']['split_method']['kwargs']
+        config['DATASET']['split_method']['name']
+    )(
+        **config['DATASET']['split_method']['kwargs']
     )
     return splitter
-
-
-# def splitter_factory(method: str, **kwargs) -> DataSplitter:
-#     """
-#     Factory function to create various splitter classes based on the specified method.
-
-#     Args:
-#         method (str): The splitting method.
-#             Supported: ['holdout', 'stratified_holdout', 'kfold', 'stratified_kfold', 'time_based']
-#         **kwargs: Additional keyword arguments for the splitter class.
-
-#     Returns:
-#         BaseSplitter: An instance of a concrete splitter class.
-#     """
-#     method = method.lower()
-#     if method == "holdout":
-#         return HoldoutSplitter(**kwargs)
-#     elif method == "stratified":
-#         return StratifiedSplitter(**kwargs)
-#     elif method == "kfold":
-#         return KFoldSplitter(**kwargs)
-#     elif method == "stratified_kfold":
-#         return StratifiedKFoldSplitter(**kwargs)
-#     else:
-#         raise ValueError(f"Unknown splitting method '{method}'.")

--- a/src/lightning_ml/utils/data/splitters/base_splitter.py
+++ b/src/lightning_ml/utils/data/splitters/base_splitter.py
@@ -5,21 +5,9 @@ from torch.utils.data import Dataset
 
 
 class DataSplitter(ABC):
-    """
-    Abstract base class for different dataset splitting strategies.
-
-    Methods:
-        split(dataset): Splits the given dataset and returns one or more subsets.
-    """
+    """Abstract base class for dataset splitting strategies."""
 
     @abstractmethod
-    def split(self, dataset: Dataset) -> Any:
-        """
-        Splits the given dataset according to the splitting strategy.
-
-        Args:
-            dataset (Dataset): The dataset to split.
-
-        Returns:
-            Any: The subsets or data structures containing the split datasets.
-        """
+    def split(self, dataset: Dataset, *args: Any, **kwargs: Any) -> Any:
+        """Split ``dataset`` and return subsets."""
+        raise NotImplementedError

--- a/src/lightning_ml/utils/data/splitters/holdout_splitter.py
+++ b/src/lightning_ml/utils/data/splitters/holdout_splitter.py
@@ -1,69 +1,13 @@
-from typing import Dict
+from typing import Any, Dict, Sequence
 
-import torch
-from torch.utils.data import Dataset, random_split
-from torch.utils.data.dataset import Subset
-
-from AML.utils.data.splitters import DataSplitter, DATA_SPLITTER_REGISTRY
+from lightning_ml.utils.data.splitters import DATA_SPLITTER_REGISTRY
+from .mixins import HoldoutMixin, RandomHoldoutMixin
 
 
+@DATA_SPLITTER_REGISTRY.register('random')
 @DATA_SPLITTER_REGISTRY.register('holdout')
-class HoldoutSplitter(DataSplitter):
-    """
-    Randomly splits the dataset into train, validation, and test splits (holdout
-    method).
+class RandomSplitter(RandomHoldoutMixin, HoldoutMixin):
+    """Random holdout splitter."""
 
-    Attributes:
-        train_ratio (float): Proportion of data to use for training.
-        val_ratio (float): Proportion of data to use for validation.
-        test_ratio (float): Proportion of data to use for testing.
-        shuffle (bool): Whether to shuffle the data before splitting.
-        random_seed (int): Random seed for reproducibility.
-    """
-
-    def __init__(
-        self,
-        train_ratio: float = 0.7,
-        val_ratio: float = 0.15,
-        test_ratio: float = 0.15,
-        shuffle: bool = True,
-        random_seed: int = 42,
-    ):
-        if not abs(train_ratio + val_ratio + test_ratio - 1.0) < 1e-6:
-            raise ValueError(
-                f"Sum of train, val, and test ratios must be 1.0. Got {train_ratio + val_ratio + test_ratio:.3f}."
-            )
-        self.train_ratio = train_ratio
-        self.val_ratio = val_ratio
-        self.test_ratio = test_ratio
-        self.shuffle = shuffle
-        self.random_seed = random_seed
-
-    def split(self, dataset: Dataset) -> Dict[str, Subset]:
-        """
-        Splits the dataset into train, validation, and test sets using the holdout method.
-
-        Args:
-            dataset (Dataset): The dataset to split.
-
-        Returns:
-            Dict[str, Subset]: A dictionary with keys 'train', 'val', and 'test',
-                mapped to their respective Subset objects.
-        """
-        dataset_size = len(dataset)
-        train_len = int(self.train_ratio * dataset_size)
-        val_len = int(self.val_ratio * dataset_size)
-        test_len = dataset_size - train_len - val_len
-
-        # Using PyTorch's random_split to create subsets
-        train_set, val_set, test_set = random_split(
-            dataset,
-            [train_len, val_len, test_len],
-            generator=torch.Generator().manual_seed(self.random_seed) if self.shuffle else None
-        )
-
-        return {
-            "train": train_set,
-            "val": val_set,
-            "test": test_set,
-        }
+    # All logic provided by mixins
+    pass

--- a/src/lightning_ml/utils/data/splitters/kfold_splitter.py
+++ b/src/lightning_ml/utils/data/splitters/kfold_splitter.py
@@ -1,53 +1,9 @@
-
-from typing import Dict, List
-
-from torch.utils.data import Dataset
-from torch.utils.data.dataset import Subset
-from sklearn.model_selection import KFold
-
-from AML.utils.data.splitters import DataSplitter, DATA_SPLITTER_REGISTRY
+from lightning_ml.utils.data.splitters import DATA_SPLITTER_REGISTRY
+from .mixins import KFoldMixin, RandomKFoldMixin
 
 
 @DATA_SPLITTER_REGISTRY.register('kfold')
-class KFoldSplitter(DataSplitter):
-    """
-    Performs K-Fold Cross-Validation splitting.
+class KFoldSplitter(RandomKFoldMixin, KFoldMixin):
+    """Standard K-Fold splitter."""
 
-    Attributes:
-        n_splits (int): Number of folds.
-        shuffle (bool): Whether to shuffle the data before splitting.
-        random_seed (int): Random seed for reproducibility.
-    """
-
-    def __init__(self, n_splits: int = 5, shuffle: bool = True, random_seed: int = 42):
-        self.n_splits = n_splits
-        self.shuffle = shuffle
-        self.random_seed = random_seed
-
-    def split(self, dataset: Dataset) -> List[Dict[str, Subset]]:
-        """
-        Splits the dataset into K folds for cross-validation.
-
-        Args:
-            dataset (Dataset): The dataset to split.
-
-        Returns:
-            List[Dict[str, Subset]]: A list of dictionaries, each containing
-                "train" and "val" subsets for each fold.
-        """
-        indices = list(range(len(dataset)))
-        kf = KFold(
-            n_splits=self.n_splits,
-            shuffle=self.shuffle,
-            random_state=self.random_seed
-        )
-
-        folds = []
-        for train_idx, val_idx in kf.split(indices):
-            train_data = Subset(dataset, train_idx)
-            val_data = Subset(dataset, val_idx)
-            folds.append({
-                "train": train_data,
-                "val": val_data
-            })
-        return folds
+    pass

--- a/src/lightning_ml/utils/data/splitters/mixins.py
+++ b/src/lightning_ml/utils/data/splitters/mixins.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Tuple
+
+import torch
+from torch.utils.data import Dataset, Subset
+from sklearn.model_selection import train_test_split, KFold, StratifiedKFold
+
+from .base_splitter import DataSplitter
+
+
+class HoldoutMixin(DataSplitter):
+    """Mixin implementing the public ``split`` for holdout-style splits."""
+
+    def __init__(
+        self,
+        train_ratio: float = 0.7,
+        val_ratio: float = 0.15,
+        test_ratio: float = 0.15,
+        shuffle: bool = True,
+        random_seed: int = 42,
+        **_: Any,
+    ) -> None:
+        if not abs(train_ratio + val_ratio + test_ratio - 1.0) < 1e-6:
+            raise ValueError(
+                f"Sum of train, val, and test ratios must be 1.0. Got {train_ratio + val_ratio + test_ratio:.3f}."
+            )
+        self.train_ratio = train_ratio
+        self.val_ratio = val_ratio
+        self.test_ratio = test_ratio
+        self.shuffle = shuffle
+        self.random_seed = random_seed
+        super().__init__()
+
+    def split(self, dataset: Dataset, targets: Sequence[Any] | None = None) -> Dict[str, Subset]:
+        indices = list(range(len(dataset)))
+        train_idx, val_idx, test_idx = self._split_indices(indices, targets)
+        return {
+            "train": Subset(dataset, train_idx),
+            "val": Subset(dataset, val_idx),
+            "test": Subset(dataset, test_idx),
+        }
+
+    def _split_indices(
+        self, indices: Sequence[int], targets: Sequence[Any] | None = None
+    ) -> Tuple[Sequence[int], Sequence[int], Sequence[int]]:
+        raise NotImplementedError
+
+
+class RandomHoldoutMixin:
+    """Implements random holdout splitting."""
+
+    def _split_indices(
+        self, indices: Sequence[int], targets: Sequence[Any] | None = None
+    ) -> Tuple[Sequence[int], Sequence[int], Sequence[int]]:
+        if targets is not None:
+            raise ValueError("targets should not be provided for RandomSplitter")
+        n = len(indices)
+        train_len = int(self.train_ratio * n)
+        val_len = int(self.val_ratio * n)
+        test_len = n - train_len - val_len
+        if self.shuffle:
+            g = torch.Generator().manual_seed(self.random_seed)
+            perm = torch.randperm(n, generator=g)
+        else:
+            perm = torch.arange(n)
+        train_idx = perm[:train_len].tolist()
+        val_idx = perm[train_len : train_len + val_len].tolist()
+        test_idx = perm[train_len + val_len :].tolist()
+        return train_idx, val_idx, test_idx
+
+
+class StratifiedHoldoutMixin:
+    """Implements stratified holdout splitting."""
+
+    def _split_indices(
+        self, indices: Sequence[int], targets: Sequence[Any] | None = None
+    ) -> Tuple[Sequence[int], Sequence[int], Sequence[int]]:
+        if targets is None:
+            raise ValueError("targets required for stratified split")
+        if len(indices) != len(targets):
+            raise ValueError("Dataset length and targets length do not match.")
+        x_temp, x_test, y_temp, y_test = train_test_split(
+            indices,
+            targets,
+            test_size=self.test_ratio,
+            stratify=targets,
+            random_state=self.random_seed,
+        )
+        val_ratio_adj = self.val_ratio / (self.train_ratio + self.val_ratio)
+        x_train, x_val, _, _ = train_test_split(
+            x_temp,
+            y_temp,
+            test_size=val_ratio_adj,
+            stratify=y_temp,
+            random_state=self.random_seed,
+        )
+        return list(x_train), list(x_val), list(x_test)
+
+
+class KFoldMixin(DataSplitter):
+    """Mixin implementing ``split`` for K-Fold style splits."""
+
+    def __init__(
+        self,
+        n_splits: int = 5,
+        shuffle: bool = True,
+        random_seed: int = 42,
+        **_: Any,
+    ) -> None:
+        self.n_splits = n_splits
+        self.shuffle = shuffle
+        self.random_seed = random_seed
+        super().__init__()
+
+    def split(self, dataset: Dataset, targets: Sequence[Any] | None = None) -> List[Dict[str, Subset]]:
+        indices = list(range(len(dataset)))
+        folds = self._split_folds(indices, targets)
+        return [
+            {"train": Subset(dataset, train), "val": Subset(dataset, val)}
+            for train, val in folds
+        ]
+
+    def _split_folds(
+        self, indices: Sequence[int], targets: Sequence[Any] | None = None
+    ) -> List[Tuple[Sequence[int], Sequence[int]]]:
+        raise NotImplementedError
+
+
+class RandomKFoldMixin:
+    """Implements standard K-Fold splitting."""
+
+    def _split_folds(
+        self, indices: Sequence[int], targets: Sequence[Any] | None = None
+    ) -> List[Tuple[Sequence[int], Sequence[int]]]:
+        if targets is not None:
+            raise ValueError("targets should not be provided for KFoldSplitter")
+        kf = KFold(
+            n_splits=self.n_splits,
+            shuffle=self.shuffle,
+            random_state=self.random_seed,
+        )
+        return [
+            (train_idx.tolist(), val_idx.tolist())
+            for train_idx, val_idx in kf.split(indices)
+        ]
+
+
+class StratifiedKFoldMixin:
+    """Implements stratified K-Fold splitting."""
+
+    def _split_folds(
+        self, indices: Sequence[int], targets: Sequence[Any] | None = None
+    ) -> List[Tuple[Sequence[int], Sequence[int]]]:
+        if targets is None:
+            raise ValueError("targets required for stratified K-Fold split")
+        if len(indices) != len(targets):
+            raise ValueError("Dataset length and targets length do not match.")
+        skf = StratifiedKFold(
+            n_splits=self.n_splits,
+            shuffle=self.shuffle,
+            random_state=self.random_seed,
+        )
+        return [
+            (train_idx.tolist(), val_idx.tolist())
+            for train_idx, val_idx in skf.split(indices, targets)
+        ]

--- a/src/lightning_ml/utils/data/splitters/stratified_kfold_splitter.py
+++ b/src/lightning_ml/utils/data/splitters/stratified_kfold_splitter.py
@@ -1,53 +1,9 @@
-from typing import Any, Dict, List
-
-from torch.utils.data import Dataset
-from torch.utils.data.dataset import Subset
-from sklearn.model_selection import StratifiedKFold
-
-from AML.utils.data.splitters import DataSplitter, DATA_SPLITTER_REGISTRY
+from lightning_ml.utils.data.splitters import DATA_SPLITTER_REGISTRY
+from .mixins import KFoldMixin, StratifiedKFoldMixin
 
 
 @DATA_SPLITTER_REGISTRY.register('stratified_kfold')
-class StratifiedKFoldSplitter(DataSplitter):
-    """
-    Performs Stratified K-Fold Cross-Validation splitting for classification tasks.
+class StratifiedKFoldSplitter(StratifiedKFoldMixin, KFoldMixin):
+    """Stratified K-Fold splitter."""
 
-    Attributes:
-        n_splits (int): Number of folds.
-        shuffle (bool): Whether to shuffle the data before splitting.
-        random_seed (int): Random seed for reproducibility.
-    """
-
-    def __init__(self, n_splits: int = 5, shuffle: bool = True, random_seed: int = 42):
-        self.n_splits = n_splits
-        self.shuffle = shuffle
-        self.random_seed = random_seed
-
-    def split(self, dataset: Dataset, targets: List[Any]) -> List[Dict[str, Subset]]:
-        """
-        Splits the dataset into K stratified folds for cross-validation.
-
-        Args:
-            dataset (Dataset): The dataset to split.
-            targets (List[Any]): List of labels/targets corresponding to the dataset.
-
-        Returns:
-            List[Dict[str, Subset]]: A list of dictionaries, each containing
-                'train' and 'val' subsets for each fold.
-        """
-        indices = list(range(len(dataset)))
-        skf = StratifiedKFold(
-            n_splits=self.n_splits,
-            shuffle=self.shuffle,
-            random_state=self.random_seed
-        )
-
-        folds = []
-        for train_idx, val_idx in skf.split(indices, targets):
-            train_data = Subset(dataset, train_idx)
-            val_data = Subset(dataset, val_idx)
-            folds.append({
-                "train": train_data,
-                "val": val_data
-            })
-        return folds
+    pass

--- a/src/lightning_ml/utils/data/splitters/stratified_splitter.py
+++ b/src/lightning_ml/utils/data/splitters/stratified_splitter.py
@@ -1,85 +1,9 @@
-from typing import Any, Dict, List
-
-import torch
-from torch.utils.data import Dataset
-from torch.utils.data.dataset import Subset
-from sklearn.model_selection import train_test_split
-
-from AML.utils.data.splitters import DataSplitter, DATA_SPLITTER_REGISTRY
+from lightning_ml.utils.data.splitters import DATA_SPLITTER_REGISTRY
+from .mixins import HoldoutMixin, StratifiedHoldoutMixin
 
 
 @DATA_SPLITTER_REGISTRY.register('stratified')
-class StratifiedSplitter(DataSplitter):
-    """
-    Splits a classification dataset into train, validation, and test splits (stratified holdout).
+class StratifiedSplitter(StratifiedHoldoutMixin, HoldoutMixin):
+    """Stratified holdout splitter."""
 
-    Attributes:
-        train_ratio (float): Proportion of data to use for training.
-        val_ratio (float): Proportion of data to use for validation.
-        test_ratio (float): Proportion of data to use for testing.
-        random_seed (int): Random seed for reproducibility.
-    """
-
-    def __init__(
-        self,
-        train_ratio: float = 0.7,
-        val_ratio: float = 0.15,
-        test_ratio: float = 0.15,
-        random_seed: int = 42,
-    ):
-        if not abs(train_ratio + val_ratio + test_ratio - 1.0) < 1e-6:
-            raise ValueError(
-                f"Sum of train, val, and test ratios must be 1.0. Got {train_ratio + val_ratio + test_ratio:.3f}."
-            )
-        self.train_ratio = train_ratio
-        self.val_ratio = val_ratio
-        self.test_ratio = test_ratio
-        self.random_seed = random_seed
-
-    def split(
-        self,
-        dataset: Dataset,
-        targets: List[Any]
-    ) -> Dict[str, Dataset]:
-        """
-        Stratified split for classification tasks. Requires access to labels/targets.
-
-        Args:
-            dataset (Dataset): The dataset to split.
-            targets (List[Any]): List of labels/targets corresponding to the dataset.
-
-        Returns:
-            Dict[str, Dataset]: Subsets with keys 'train', 'val', 'test'.
-        """
-        if len(dataset) != len(targets):
-            raise ValueError("Dataset length and targets length do not match.")
-
-        # First split (train + val / test)
-        X_temp_indices, X_test_indices, y_temp, y_test = train_test_split(
-            range(len(dataset)),
-            targets,
-            test_size=self.test_ratio,
-            stratify=targets,
-            random_state=self.random_seed
-        )
-
-        # Second split (train / val)
-        val_ratio_adjusted = self.val_ratio / (self.train_ratio + self.val_ratio)
-        X_train_indices, X_val_indices, y_train, y_val = train_test_split(
-            X_temp_indices,
-            y_temp,
-            test_size=val_ratio_adjusted,
-            stratify=y_temp,
-            random_state=self.random_seed
-        )
-
-        # Convert indices to Subset objects
-        train_data = Subset(dataset, X_train_indices)
-        val_data = Subset(dataset, X_val_indices)
-        test_data = Subset(dataset, X_test_indices)
-
-        return {
-            "train": train_data,
-            "val": val_data,
-            "test": test_data
-        }
+    pass


### PR DESCRIPTION
## Summary
- add generic splitting mixins
- implement Random, Stratified, KFold and StratifiedKFold splitters using mixins
- rename Holdout splitter to Random splitter

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684a926e0014832d87576902fdf3f0c0