### PR TITLE
Add SemiSupervised learner

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To define a learner, you have to define the code that pipes a batch to model out
 src/lightning_ml/
 ├── core/        # base classes: Learner, Predictor, Dataset, DataModule, Project
 ├── datasets/    # dataset mix-ins and concrete dataset implementations
-├── learners/    # common learning paradigms (Supervised, Unsupervised, Contrastive)
+├── learners/    # common learning paradigms (Supervised, Unsupervised, Contrastive, SemiSupervised)
 ├── models/      # model registry and example model
 ├── predictors/  # output post-processing utilities
 └── utils/       # helper functions (registries, class binding, ...)

--- a/src/lightning_ml/learners/__init__.py
+++ b/src/lightning_ml/learners/__init__.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from .contrastive import *
+from .contrastive import Contrastive
 from .supervised import Supervised
 from .unsupervised import Unsupervised
+from .semi_supervised import SemiSupervised
 
 __all__ = [
     "Supervised",
     "Unsupervised",
-    "ContrastiveSupervised",
-    "ContrastiveUnsupervised",
+    "SemiSupervised",
+    "Contrastive",
 ]

--- a/src/lightning_ml/learners/semi_supervised.py
+++ b/src/lightning_ml/learners/semi_supervised.py
@@ -1,0 +1,41 @@
+"""Semi-supervised learning paradigm."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Callable
+
+from torch import Tensor
+
+from ..core import Learner
+
+__all__ = ["SemiSupervised"]
+
+
+class SemiSupervised(Learner):
+    """Generic semi-supervised learning task.
+
+    Combines supervised and unsupervised objectives using ``criterion`` for
+    supervised loss and ``unsupervised_criterion`` for unsupervised loss.
+    The two losses are weighted by ``lambda_u``.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        unsupervised_criterion: Callable[[Any], Tensor],
+        lambda_u: float = 1.0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.unsupervised_criterion = unsupervised_criterion
+        self.lambda_u = lambda_u
+
+    def batch_forward(self, batch: Dict[str, Any]) -> Any:
+        """Forward hook to underlying model ``self.model``"""
+        return self.model(batch["input"])
+
+    def compute_loss(self, model_outputs: Any, targets: Optional[Any] = None) -> Tensor:
+        """Compute weighted semi-supervised loss."""
+        loss_u = self.unsupervised_criterion(model_outputs)
+        loss_s = self.criterion(model_outputs, targets) if targets is not None else 0
+        return loss_s + self.lambda_u * loss_u


### PR DESCRIPTION
## Summary
- implement a `SemiSupervised` learner mixing supervised and unsupervised losses
- expose the learner via `lightning_ml.learners`
- document the new learner in the repository overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a8d8b76c832d8b72fe1df7c02a82