### PR TITLE
Add torchvision registration utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To define a learner, you have to define the code that pipes a batch to model out
 - **Generic datamodule** – the `DataModule` can turn any dataset into Lightning data loaders with optional train/val/test splits.
 - **Component registries** – simple registry mechanism for declaring and retrieving
   datasets, learners, models and predictors by name.
+- **Torchvision integration** – utility functions to auto-register torchvision models and datasets.
 - **Project orchestration** – the `Project` class wires together a learner and a Lightning `Trainer` instance for a concise training loop.
 
 ## Repository layout

--- a/src/lightning_ml/utils/__init__.py
+++ b/src/lightning_ml/utils/__init__.py
@@ -1,3 +1,18 @@
 from . import data, inspect
 from .registry import Registry
+from .torchvision import (
+    register_torchvision,
+    register_torchvision_datasets,
+    register_torchvision_models,
+)
 from .utils import *
+
+__all__ = [
+    "data",
+    "inspect",
+    "Registry",
+    "bind_classes",
+    "register_torchvision",
+    "register_torchvision_datasets",
+    "register_torchvision_models",
+]

--- a/src/lightning_ml/utils/torchvision.py
+++ b/src/lightning_ml/utils/torchvision.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import inspect
+from typing import Optional
+
+from .registry import Registry
+
+__all__ = ["register_torchvision_models", "register_torchvision_datasets", "register_torchvision"]
+
+
+def _import_torchvision():
+    try:
+        import torchvision
+        return torchvision
+    except Exception as e:
+        raise ImportError("torchvision is required for this functionality") from e
+
+
+def register_torchvision_models(registry: Optional[Registry] = None) -> None:
+    """Register all torchvision model functions and classes."""
+    tv = _import_torchvision()
+    from ..models import MODEL_REG  # local import to avoid circular dependency
+    registry = registry or MODEL_REG
+
+    for name, obj in inspect.getmembers(tv.models):
+        if name.startswith("_"):
+            continue
+        if callable(obj):
+            try:
+                registry.register(name)(obj)
+            except KeyError:
+                pass
+
+
+def register_torchvision_datasets(registry: Optional[Registry] = None) -> None:
+    """Register all torchvision dataset classes."""
+    tv = _import_torchvision()
+    from ..datasets import DATASET_REG
+    registry = registry or DATASET_REG
+
+    try:
+        from torch.utils.data import Dataset
+    except Exception as e:
+        raise ImportError("PyTorch is required for this functionality") from e
+
+    for name, obj in inspect.getmembers(tv.datasets, inspect.isclass):
+        if name.startswith("_"):
+            continue
+        if issubclass(obj, Dataset):
+            try:
+                registry.register(name)(obj)
+            except KeyError:
+                pass
+
+
+def register_torchvision() -> None:
+    """Register both torchvision datasets and models."""
+    register_torchvision_models()
+    register_torchvision_datasets()

--- a/tests/test_torchvision_registry.py
+++ b/tests/test_torchvision_registry.py
@@ -1,0 +1,87 @@
+import sys
+import types
+
+
+def test_register_torchvision_modules():
+    # Stub torch and dependencies as in existing tests
+    torch = types.ModuleType('torch')
+    torch.Tensor = object
+    torch.nn = types.ModuleType('nn')
+    torch.nn.Module = object
+    torch.nn.ModuleDict = object
+    torch.utils = types.ModuleType('utils'); torch.utils.data = types.ModuleType('data')
+    torch.utils.data.Dataset = object
+    torch.utils.data.DataLoader = object
+    torch.utils.data.Subset = object
+    torch.optim = types.ModuleType('optim')
+    torch.optim.lr_scheduler = types.ModuleType('lr_scheduler')
+    torch.optim.lr_scheduler._LRScheduler = object
+    torch.optim.optimizer = types.ModuleType('optimizer')
+    torch.optim.optimizer.Optimizer = object
+    sys.modules['torch.optim'] = torch.optim
+    sys.modules['torch.optim.lr_scheduler'] = torch.optim.lr_scheduler
+    sys.modules['torch.optim.optimizer'] = torch.optim.optimizer
+    sys.modules['torch'] = torch
+    sys.modules['torch.nn'] = torch.nn
+    sys.modules['torch.utils'] = torch.utils
+    sys.modules['torch.utils.data'] = torch.utils.data
+
+    pl = types.ModuleType('pytorch_lightning')
+    pl.LightningModule = type('LightningModule', (), {})
+    pl.LightningDataModule = type('LightningDataModule', (), {})
+    pl.Trainer = type('Trainer', (), {})
+    sys.modules['pytorch_lightning'] = pl
+
+    sys.modules['pandas'] = types.ModuleType('pandas')
+    sys.modules['numpy'] = types.ModuleType('numpy')
+    PIL = types.ModuleType('PIL'); PIL_Image = types.ModuleType('PIL.Image')
+    sys.modules['PIL'] = PIL; sys.modules['PIL.Image'] = PIL_Image
+    sklearn = types.ModuleType('sklearn')
+    sklearn_ms = types.ModuleType('sklearn.model_selection')
+    sklearn_split = types.ModuleType('sklearn.model_selection._split')
+    sklearn_split.BaseCrossValidator = object
+    sys.modules['sklearn'] = sklearn
+    sys.modules['sklearn.model_selection'] = sklearn_ms
+    sys.modules['sklearn.model_selection._split'] = sklearn_split
+    torchmetrics = types.ModuleType('torchmetrics')
+    torchmetrics.MetricCollection = object
+    sys.modules['torchmetrics'] = torchmetrics
+
+    # Stub torchvision with simple dataset and model
+    tv = types.ModuleType('torchvision')
+    tv_datasets = types.ModuleType('torchvision.datasets')
+    tv_models = types.ModuleType('torchvision.models')
+
+    class DummyDataset(torch.utils.data.Dataset):
+        pass
+
+    class DummyModel(torch.nn.Module):
+        pass
+
+    def dummy_model_fn():
+        return 'model'
+
+    tv_datasets.DummyDataset = DummyDataset
+    tv_models.DummyModel = DummyModel
+    tv_models.dummy_model_fn = dummy_model_fn
+
+    tv.datasets = tv_datasets
+    tv.models = tv_models
+    sys.modules['torchvision'] = tv
+    sys.modules['torchvision.datasets'] = tv_datasets
+    sys.modules['torchvision.models'] = tv_models
+
+    sys.path.insert(0, 'src')
+
+    from lightning_ml.datasets import DATASET_REG
+    from lightning_ml.models import MODEL_REG
+    from lightning_ml.utils.torchvision import register_torchvision
+
+    DATASET_REG.clear()
+    MODEL_REG.clear()
+
+    register_torchvision()
+
+    assert 'DummyDataset' in DATASET_REG
+    assert 'DummyModel' in MODEL_REG
+    assert 'dummy_model_fn' in MODEL_REG


### PR DESCRIPTION
## Summary
- add bullet on torchvision integration
- add torchvision registration functions to utils
- expose registration helpers
- unit test to verify torchvision auto-registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584fd7d454832dbd992d05912772dc