### PR TITLE
Allow dataset splitting in DataModule

### DIFF
--- a/src/lightning_ml/core/__init__.py
+++ b/src/lightning_ml/core/__init__.py
@@ -6,6 +6,6 @@ from .datamodule import DataModule
 from .dataset import BaseDataset
 from .learner import Learner
 from .predictor import Predictor
-from .project import School
+from .school import School
 
 __all__ = ["Learner", "Predictor", "School", "BaseDataset", "DataModule"]


### PR DESCRIPTION
## Summary
- support passing a dataset dict or a dataset with a splitter to `DataModule`
- fix incorrect import in `core.__init__`
- relax torchvision model registration to work without `list_models`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859335b044c832d8fa8d949fbe35ee2