### PR TITLE
Add torchvision dataset wrapper

### DIFF
--- a/src/lightning_ml/core/datamodule.py
+++ b/src/lightning_ml/core/datamodule.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Optional, Type
+
+try:
+    import pytorch_lightning as pl
+    from torch.utils.data import DataLoader
+except Exception as e:  # pragma: no cover - import dependency
+    raise ImportError("PyTorch Lightning and torch are required") from e
+
+from .dataset import BaseDataset
+
+
+class DataModule(pl.LightningDataModule):
+    """Minimal Lightning ``DataModule`` for a single dataset."""
+
+    def __init__(
+        self,
+        dataset_cls: Type[BaseDataset],
+        *,
+        dataset_kwargs: Optional[dict[str, Any]] = None,
+        dataloader_kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        self.dataset_cls = dataset_cls
+        self.dataset_kwargs = dataset_kwargs or {}
+        self.dataloader_kwargs = dataloader_kwargs or {}
+        self.dataset: Optional[BaseDataset] = None
+
+    def setup(self, stage: Optional[str] = None) -> None:
+        self.dataset = self.dataset_cls(**self.dataset_kwargs)
+
+    def train_dataloader(self) -> DataLoader:
+        return DataLoader(self.dataset, **self.dataloader_kwargs)

--- a/src/lightning_ml/datasets/__init__.py
+++ b/src/lightning_ml/datasets/__init__.py
@@ -10,6 +10,7 @@ from .abstract import *  # noqa: F401,F403
 from .contrastive import *  # noqa: F401,F403
 from .labelled import *  # noqa: F401,F403
 from .disk import *  # noqa: F401,F403
+from .torchvision_wrapper import *  # noqa: F401,F403
 
 __all__ = [
     "DATASET_REG",
@@ -22,4 +23,5 @@ __all__ = [
     "ContrastiveLabelledDataset",
     "ContrastiveUnlabelledDataset",
     "TripletDataset",
+    "TorchvisionDataset",
 ]

--- a/src/lightning_ml/datasets/torchvision_wrapper.py
+++ b/src/lightning_ml/datasets/torchvision_wrapper.py
@@ -1,0 +1,44 @@
+"""Wrapper classes to adapt torchvision datasets to Lightning-ML's Dataset API."""
+
+from __future__ import annotations
+
+from typing import Any, Type
+
+from . import DATASET_REG
+from .abstract import LabelledDatasetBase
+
+__all__ = ["TorchvisionDataset"]
+
+try:
+    from torch.utils.data import Dataset as TorchDataset
+except Exception as e:  # pragma: no cover - import dependency
+    raise ImportError("PyTorch is required for TorchvisionDataset") from e
+
+
+@DATASET_REG.register()
+class TorchvisionDataset(LabelledDatasetBase):
+    """Wrap a torchvision dataset returning ``(input, target)`` tuples."""
+
+    def __init__(self, dataset: TorchDataset | Type[TorchDataset], **kwargs: Any) -> None:
+        if isinstance(dataset, type):
+            dataset = dataset(**kwargs)
+        self.dataset = dataset
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+    def _get_tuple(self, idx: int) -> tuple[Any, Any]:
+        sample = self.dataset[idx]
+        if not isinstance(sample, tuple) or len(sample) < 2:
+            raise ValueError(
+                "Underlying dataset must return a tuple (input, target)"
+            )
+        return sample[0], sample[1]
+
+    def get_input(self, idx: int) -> Any:
+        inp, _ = self._get_tuple(idx)
+        return inp
+
+    def get_target(self, idx: int) -> Any:
+        _, tgt = self._get_tuple(idx)
+        return tgt

--- a/src/lightning_ml/utils/__init__.py
+++ b/src/lightning_ml/utils/__init__.py
@@ -1,9 +1,8 @@
-from . import data, inspect, torchvision
+from . import inspect, torchvision
 from .registry import Registry
 from .utils import *
 
 __all__ = [
-    "data",
     "inspect",
     "Registry",
     "bind_classes",

--- a/tests/test_torchvision_wrapper.py
+++ b/tests/test_torchvision_wrapper.py
@@ -1,0 +1,79 @@
+import sys
+import types
+import importlib
+
+
+def test_torchvision_dataset_wrapper():
+    # Stub torch and dependencies
+    torch = types.ModuleType('torch')
+    torch.Tensor = object
+    torch.nn = types.ModuleType('nn')
+    torch.nn.Module = object
+    torch.nn.ModuleDict = object
+    torch.utils = types.ModuleType('utils'); torch.utils.data = types.ModuleType('data')
+    class BaseDataset(object):
+        pass
+    torch.utils.data.Dataset = BaseDataset
+    torch.utils.data.DataLoader = object
+    torch.utils.data.Subset = object
+    torch.optim = types.ModuleType('optim')
+    torch.optim.lr_scheduler = types.ModuleType('lr_scheduler')
+    torch.optim.lr_scheduler._LRScheduler = object
+    torch.optim.optimizer = types.ModuleType('optimizer')
+    torch.optim.optimizer.Optimizer = object
+    sys.modules['torch.optim'] = torch.optim
+    sys.modules['torch.optim.lr_scheduler'] = torch.optim.lr_scheduler
+    sys.modules['torch.optim.optimizer'] = torch.optim.optimizer
+    sys.modules['torch'] = torch
+    sys.modules['torch.nn'] = torch.nn
+    sys.modules['torch.utils'] = torch.utils
+    sys.modules['torch.utils.data'] = torch.utils.data
+
+    pl = types.ModuleType('pytorch_lightning')
+    pl.LightningModule = type('LightningModule', (), {})
+    pl.LightningDataModule = type('LightningDataModule', (), {})
+    pl.Trainer = type('Trainer', (), {})
+    sys.modules['pytorch_lightning'] = pl
+
+    sys.modules['pandas'] = types.ModuleType('pandas')
+    sys.modules['numpy'] = types.ModuleType('numpy')
+    PIL = types.ModuleType('PIL'); PIL_Image = types.ModuleType('PIL.Image')
+    sys.modules['PIL'] = PIL; sys.modules['PIL.Image'] = PIL_Image
+    sklearn = types.ModuleType('sklearn')
+    sklearn_ms = types.ModuleType('sklearn.model_selection')
+    sklearn_split = types.ModuleType('sklearn.model_selection._split')
+    sklearn_split.BaseCrossValidator = object
+    sys.modules['sklearn'] = sklearn
+    sys.modules['sklearn.model_selection'] = sklearn_ms
+    sys.modules['sklearn.model_selection._split'] = sklearn_split
+    torchmetrics = types.ModuleType('torchmetrics')
+    torchmetrics.MetricCollection = object
+    sys.modules['torchmetrics'] = torchmetrics
+
+    # Define dummy torchvision dataset
+    tv = types.ModuleType('torchvision')
+    tv_datasets = types.ModuleType('torchvision.datasets')
+
+    class DummyDataset(torch.utils.data.Dataset):
+        def __init__(self):
+            self.data = [(1, 'a'), (2, 'b')]
+
+        def __len__(self):
+            return len(self.data)
+
+        def __getitem__(self, idx):
+            return self.data[idx]
+
+    tv_datasets.DummyDataset = DummyDataset
+    tv.datasets = tv_datasets
+    sys.modules['torchvision'] = tv
+    sys.modules['torchvision.datasets'] = tv_datasets
+
+    sys.path.insert(0, 'src')
+    datasets = importlib.import_module('lightning_ml.datasets')
+
+    ds = datasets.TorchvisionDataset(DummyDataset())
+    assert len(ds) == 2
+    assert ds.get_input(0) == 1
+    assert ds.get_target(1) == 'b'
+


### PR DESCRIPTION
## Summary
- add `TorchvisionDataset` to adapt torchvision datasets
- expose the wrapper via dataset registry
- add minimal `DataModule` so imports succeed
- fix utils init
- test torchvision wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ee78addc832daadf8ffcb6063319