### PR TITLE
Update type hints to Python 3.10 style

### DIFF
--- a/src/lightning_ml/core/data/datamodule.py
+++ b/src/lightning_ml/core/data/datamodule.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type
+from collections.abc import Callable
 
 import pytorch_lightning as pl
 from sklearn.model_selection._split import BaseCrossValidator
@@ -28,14 +29,14 @@ class DataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        train_data: Optional[BaseDataset],
-        val_data: Optional[BaseDataset] = None,
-        test_data: Optional[BaseDataset] = None,
-        predict_data: Optional[BaseDataset] = None,
-        val_split: Optional[float] = None,
-        test_split: Optional[float] = None,
-        transform: Optional[Callable] = None,
-        target_transform: Optional[Callable] = None,
+        train_data: BaseDataset | None,
+        val_data: BaseDataset | None = None,
+        test_data: BaseDataset | None = None,
+        predict_data: BaseDataset | None = None,
+        val_split: float | None = None,
+        test_split: float | None = None,
+        transform: Callable | None = None,
+        target_transform: Callable | None = None,
         **dataloader_kwargs,
     ) -> None:
         super().__init__()
@@ -72,37 +73,37 @@ class DataModule(pl.LightningDataModule):
         self.dataloader_kwargs = dataloader_kwargs
 
     @property
-    def train_dataset(self) -> Optional[BaseDataset]:
+    def train_dataset(self) -> BaseDataset | None:
         """This property returns the train dataset."""
         return self._train_data
 
     @property
-    def val_dataset(self) -> Optional[BaseDataset]:
+    def val_dataset(self) -> BaseDataset | None:
         """This property returns the validation dataset."""
         return self._val_data
 
     @property
-    def test_dataset(self) -> Optional[BaseDataset]:
+    def test_dataset(self) -> BaseDataset | None:
         """This property returns the test dataset."""
         return self._test_data
 
     @property
-    def predict_dataset(self) -> Optional[BaseDataset]:
+    def predict_dataset(self) -> BaseDataset | None:
         """This property returns the prediction dataset."""
         return self._predict_data
 
     def train_dataloader(self) -> DataLoader:
         return DataLoader(self.train_dataset, shuffle=True, **self.dataloader_kwargs)
 
-    def val_dataloader(self) -> Optional[DataLoader]:
+    def val_dataloader(self) -> DataLoader | None:
         if self.val_dataset is not None:
             return DataLoader(self.val_dataset, **self.dataloader_kwargs)
 
-    def test_dataloader(self) -> Optional[DataLoader]:
+    def test_dataloader(self) -> DataLoader | None:
         if self.test_dataset is not None:
             return DataLoader(self.test_dataset, **self.dataloader_kwargs)
 
     @classmethod
-    def from_config(cls, cfg: dict) -> "DataModule":
+    def from_config(cls, cfg: dict) -> DataModule:
         # TODO
         raise NotImplementedError

--- a/src/lightning_ml/core/data/dataset.py
+++ b/src/lightning_ml/core/data/dataset.py
@@ -28,8 +28,6 @@ import torch
 from torch.utils.data import Dataset
 
 from ..utils.enums import DataKeys
-from .properties import Properties
-from .target_formatter import TargetFormatter, get_target_formatter
 
 __all__ = [
     "BaseDataset",
@@ -55,7 +53,7 @@ class DatasetMeta(ABCMeta):
     """
 
     def __new__(
-        mcls, name: str, bases: Tuple[type, ...], namespace: Dict[str, Any]
+        mcls, name: str, bases: tuple[type, ...], namespace: dict[str, Any]
     ) -> "DatasetMeta":
         """
         Construct a new class, injecting abstractmethod stubs.
@@ -69,12 +67,12 @@ class DatasetMeta(ABCMeta):
             AutoAbstractMeta: The newly created class with injected stubs.
         """
         # Determine declared and inherited sample_keys, then form their union
-        declared_keys: List[str] = namespace.get("sample_keys", [])
-        inherited_keys: List[str] = []
+        declared_keys: list[str] = namespace.get("sample_keys", [])
+        inherited_keys: list[str] = []
         for base in bases:
             inherited_keys.extend(getattr(base, "sample_keys", []))
         # Combine inherited and declared, preserving order and uniqueness
-        keys_list: List[str] = []
+        keys_list: list[str] = []
         for k in inherited_keys + declared_keys:
             if k not in keys_list:
                 keys_list.append(k)
@@ -109,9 +107,9 @@ class BaseDataset(Dataset, metaclass=DatasetMeta):
         sample_keys (List[str]): Keys defining each component returned by __getitem__.
     """
 
-    sample_keys: List[str] = []
+    sample_keys: list[str] = []
 
-    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
         """
         Retrieve a sample by index.
 

--- a/src/lightning_ml/core/data/dtype.py
+++ b/src/lightning_ml/core/data/dtype.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List
+from collections.abc import Sequence
 
 from lightning_ml.core.data.dataset import BaseDataset, LabelledDatasetBase, TargetMixin
 
@@ -19,7 +20,7 @@ class DType(ABC):
             Sequence[Any]: _description_
         """
 
-    def process_sample(self, sample: Dict[str, Any]) -> Dict[str, Any]:
+    def process_sample(self, sample: dict[str, Any]) -> dict[str, Any]:
         """Process sample (e.g. add metadata)
 
         Returns:
@@ -44,7 +45,7 @@ class YOLOFolder(LabelledDatasetBase):
         # load file and return raw here
         pass
 
-    def get_target(self, idx) -> Dict[str, Any]:
+    def get_target(self, idx) -> dict[str, Any]:
         """Process sample (e.g. add metadata)
 
         Returns:
@@ -56,7 +57,7 @@ class YOLOFolder(LabelledDatasetBase):
 class Target(TargetMixin):
     """Base class for target dicts (e.g. {bboxes.., labels...})"""
 
-    sample_keys: List[str] = []
+    sample_keys: list[str] = []
 
     def get_target(self, idx):
         return {k: getattr(self, f"get_{k}")(idx) for k in self.sample_keys}

--- a/src/lightning_ml/core/data/sample.py
+++ b/src/lightning_ml/core/data/sample.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional
+from collections.abc import Sequence
 
 from ..utils.enums import DataKeys
 
@@ -26,11 +27,11 @@ class Sample:  # noqa: D101
     """
 
     input: Any
-    preds: Optional[Any] = None
-    target: Optional[Any] = None
-    positive: Optional[Any] = None
-    negative: Optional[Any] = None
-    metadata: Optional[Dict[str, Any]] = field(default_factory=dict)
+    preds: Any | None = None
+    target: Any | None = None
+    positive: Any | None = None
+    negative: Any | None = None
+    metadata: dict[str, Any] | None = field(default_factory=dict)
 
     def __getitem__(self, key: str | DataKeys) -> Any:
         if isinstance(key, str):
@@ -55,7 +56,7 @@ class Sample:  # noqa: D101
             return list(DataKeys)
         return [k for k in DataKeys if getattr(self, k.value) is not None]
 
-    def to_dict(self, include_none: bool = False) -> Dict[str, Any]:
+    def to_dict(self, include_none: bool = False) -> dict[str, Any]:
         """Return a plain ``dict`` representation of the sample.
 
         Args:

--- a/src/lightning_ml/core/data/target_formatter.py
+++ b/src/lightning_ml/core/data/target_formatter.py
@@ -30,11 +30,11 @@ class TargetFormatter(ABC):
 
     """
 
-    multi_label: ClassVar[Optional[bool]] = None
-    numeric: ClassVar[Optional[bool]] = None
-    binary: ClassVar[Optional[bool]] = None
-    labels: Optional[List[str]] = None
-    num_classes: Optional[int] = None
+    multi_label: ClassVar[bool | None] = None
+    numeric: ClassVar[bool | None] = None
+    binary: ClassVar[bool | None] = None
+    labels: list[str] | None = None
+    num_classes: int | None = None
 
     def __post_init__(self):
         self.num_classes = (

--- a/src/lightning_ml/core/school.py
+++ b/src/lightning_ml/core/school.py
@@ -10,7 +10,7 @@ from .learner import Learner
 class School:
     """Orchestrates a :class:`Learner` and a :class:`~pytorch_lightning.Trainer`."""
 
-    def __init__(self, learner: Learner, trainer: Optional[Trainer] = None) -> None:
+    def __init__(self, learner: Learner, trainer: Trainer | None = None) -> None:
         """Create a new project.
 
         Parameters
@@ -26,7 +26,7 @@ class School:
 
     # ------------------------------------------------------------------
     @property
-    def data(self) -> Optional[LightningDataModule]:
+    def data(self) -> LightningDataModule | None:
         """Convenience access to the learner's data_module."""
         return self.learner.data_module
 

--- a/src/lightning_ml/core/utils/enums.py
+++ b/src/lightning_ml/core/utils/enums.py
@@ -1,4 +1,7 @@
-from pytorch_lightning.utilities.enums import LightningEnum
+try:  # pragma: no cover - optional dependency
+    from pytorch_lightning.utilities.enums import LightningEnum
+except Exception:  # pragma: no cover - fallback when PL not installed
+    from enum import Enum as LightningEnum
 
 
 class DataKeys(LightningEnum):

--- a/src/lightning_ml/core/utils/imports.py
+++ b/src/lightning_ml/core/utils/imports.py
@@ -164,7 +164,7 @@ _EXTRAS_AVAILABLE = {
 }
 
 
-def requires(*module_paths: Union[str, Tuple[bool, str]]):
+def requires(*module_paths: str | tuple[bool, str]):
     """Decorator factory to enforce optional dependencies.
 
     Checks that specified modules or extras are available before allowing
@@ -219,5 +219,5 @@ def requires(*module_paths: Union[str, Tuple[bool, str]]):
     return decorator
 
 
-def example_requires(module_paths: Union[str, List[str]]):
+def example_requires(module_paths: str | list[str]):
     return requires(module_paths)(lambda: None)()

--- a/src/lightning_ml/core/utils/loading.py
+++ b/src/lightning_ml/core/utils/loading.py
@@ -77,7 +77,7 @@ PATH_TYPE = Union[str, bytes, os.PathLike]
 
 
 def has_file_allowed_extension(
-    filename: PATH_TYPE, extensions: Tuple[str, ...]
+    filename: PATH_TYPE, extensions: tuple[str, ...]
 ) -> bool:
     """Checks if a file is an allowed extension.
 
@@ -307,7 +307,7 @@ def escape_url(url: str) -> str:
     return f"{parsed.scheme}://{parsed.netloc}{quote(parsed.path)}?{urlencode(parse_qs(parsed.query), doseq=True)}"
 
 
-def escape_file_path(file_path: Union[str, PathLike]) -> str:
+def escape_file_path(file_path: str | PathLike) -> str:
     """Escape a file system path or URL for fsspec opening.
 
     Uses glob.escape for local paths and escape_url for remote URLs.

--- a/src/lightning_ml/datasets/__init__.py
+++ b/src/lightning_ml/datasets/__init__.py
@@ -10,7 +10,7 @@ from .abstract import *  # noqa: F401,F403
 from .contrastive import *  # noqa: F401,F403
 from .labelled import *  # noqa: F401,F403
 from .disk import *  # noqa: F401,F403
-from . import wrappers  # noqa: F401,F403
+from .wrappers import TorchvisionDataset
 
 __all__ = [
     "DATASET_REG",
@@ -23,4 +23,5 @@ __all__ = [
     "ContrastiveLabelledDataset",
     "ContrastiveUnlabelledDataset",
     "TripletDataset",
+    "TorchvisionDataset",
 ]

--- a/src/lightning_ml/datasets/abstract.py
+++ b/src/lightning_ml/datasets/abstract.py
@@ -6,7 +6,8 @@ This module provides:
 - UnlabelledDatasetBase, LabelledDatasetBase, ContastiveDatasetBase, TripletDatasetBase: abstract dataset base classes combining mix-ins.
 """
 
-from typing import Any, Sequence
+from typing import Any
+from collections.abc import Sequence
 
 from ..core import BaseDataset
 

--- a/src/lightning_ml/datasets/contrastive.py
+++ b/src/lightning_ml/datasets/contrastive.py
@@ -8,7 +8,8 @@ This module provides:
 """
 
 import random
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Optional
+from collections.abc import Callable, Sequence
 
 from . import DATASET_REG
 from .abstract import ContastiveDatasetBase, TripletDatasetBase
@@ -38,8 +39,8 @@ class ContrastiveLabelledDataset(LabelledDataset, ContastiveDatasetBase):
         inputs: Sequence[Any],
         targets: Sequence[Any],
         *,
-        transform: Optional[Callable[[Any], Any]] = None,
-        target_transform: Optional[Callable[[Any], Any]] = None,
+        transform: Callable[[Any], Any] | None = None,
+        target_transform: Callable[[Any], Any] | None = None,
     ) -> None:
         """
         Initialize the contrastive-labelled dataset.
@@ -93,7 +94,7 @@ class ContrastiveUnlabelledDataset(UnlabelledDataset, ContastiveDatasetBase):
     def __init__(
         self,
         inputs: Sequence[Any],
-        transform: Optional[Callable[[Any], Any]] = None,
+        transform: Callable[[Any], Any] | None = None,
     ) -> None:
         """
         Initialize the unlabelled contrastive dataset.

--- a/src/lightning_ml/datasets/disk.py
+++ b/src/lightning_ml/datasets/disk.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Optional
+from collections.abc import Callable, Sequence
 
 import numpy as np
 import pandas as pd
@@ -29,7 +30,7 @@ class NumpyUnlabelledDataset(UnlabelledDataset):
         self,
         inputs: str | Sequence[Any] | np.ndarray,
         *,
-        transform: Optional[Callable[[Any], Any]] = None,
+        transform: Callable[[Any], Any] | None = None,
     ) -> None:
         if isinstance(inputs, str):
             inputs = np.load(inputs)
@@ -45,8 +46,8 @@ class NumpyLabelledDataset(LabelledDataset):
         inputs: str | Sequence[Any] | np.ndarray,
         targets: str | Sequence[Any] | np.ndarray,
         *,
-        transform: Optional[Callable[[Any], Any]] = None,
-        target_transform: Optional[Callable[[Any], Any]] = None,
+        transform: Callable[[Any], Any] | None = None,
+        target_transform: Callable[[Any], Any] | None = None,
     ) -> None:
         if isinstance(inputs, str):
             inputs = np.load(inputs)
@@ -70,9 +71,9 @@ class CSVDataset(LabelledDataset):
         input_cols: Sequence[str],
         target_col: str,
         *,
-        transform: Optional[Callable[[Any], Any]] = None,
-        target_transform: Optional[Callable[[Any], Any]] = None,
-        pandas_kwargs: Optional[dict] = None,
+        transform: Callable[[Any], Any] | None = None,
+        target_transform: Callable[[Any], Any] | None = None,
+        pandas_kwargs: dict | None = None,
     ) -> None:
         df = pd.read_csv(csv_path, **(pandas_kwargs or {}))
         inputs = df[input_cols].values
@@ -90,8 +91,8 @@ class ImageFolderDataset(LabelledDataset):
         self,
         root: str,
         *,
-        transform: Optional[Callable[[Image.Image], Any]] = None,
-        target_transform: Optional[Callable[[Any], Any]] = None,
+        transform: Callable[[Image.Image], Any] | None = None,
+        target_transform: Callable[[Any], Any] | None = None,
         image_extensions: Sequence[str] | None = None,
     ) -> None:
         self.root = root

--- a/src/lightning_ml/datasets/labelled.py
+++ b/src/lightning_ml/datasets/labelled.py
@@ -5,7 +5,8 @@ This module provides a simple in-memory labeled dataset that stores
 input and target sequences.
 """
 
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Optional
+from collections.abc import Callable, Sequence
 
 from . import DATASET_REG
 from .abstract import LabelledDatasetBase
@@ -38,8 +39,8 @@ class LabelledDataset(LabelledDatasetBase):
         inputs: Sequence[Any],
         targets: Sequence[Any],
         *,
-        transform: Optional[Callable[[Any], Any]] = None,
-        target_transform: Optional[Callable[[Any], Any]] = None,
+        transform: Callable[[Any], Any] | None = None,
+        target_transform: Callable[[Any], Any] | None = None,
     ) -> None:
         if len(inputs) != len(targets):
             raise ValueError("inputs and targets must have the same length")

--- a/src/lightning_ml/datasets/unlabelled.py
+++ b/src/lightning_ml/datasets/unlabelled.py
@@ -5,7 +5,8 @@ This module provides a simple in-memory labeled dataset that stores
 input and target sequences.
 """
 
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Optional
+from collections.abc import Callable, Sequence
 
 from . import DATASET_REG
 from .abstract import UnlabelledDatasetBase
@@ -35,7 +36,7 @@ class UnlabelledDataset(UnlabelledDatasetBase):
         self,
         inputs: Sequence[Any],
         *,
-        transform: Optional[Callable[[Any], Any]] = None,
+        transform: Callable[[Any], Any] | None = None,
     ) -> None:
         self._inputs = inputs
         self.transform = transform or (lambda x: x)

--- a/src/lightning_ml/datasets/wrappers/torchvision.py
+++ b/src/lightning_ml/datasets/wrappers/torchvision.py
@@ -26,7 +26,7 @@ class TorchvisionDataset(LabelledDatasetBase):
     dataset: TorchDataset
 
     def __init__(
-        self, dataset: TorchDataset | Type[TorchDataset], **kwargs: Any
+        self, dataset: TorchDataset | type[TorchDataset], **kwargs: Any
     ) -> None:
         """Initializes the TorchvisionDataset.
 

--- a/src/lightning_ml/image/data.py
+++ b/src/lightning_ml/image/data.py
@@ -1,5 +1,6 @@
 from glob import glob
-from typing import Any, Callable, Dict, Sequence
+from typing import Any, Dict
+from collections.abc import Callable, Sequence
 
 from lightning_ml.core.data.dataset import BaseDataset
 from lightning_ml.datasets.labelled import LabelledDataset
@@ -11,7 +12,7 @@ from ..core.utils.loading import load_image
 
 class Image(DType):
 
-    def process_sample(self, sample: Dict[str, Any]) -> Dict[str, Any]:
+    def process_sample(self, sample: dict[str, Any]) -> dict[str, Any]:
         """Add img metadata
 
         Args:

--- a/src/lightning_ml/learners/contrastive.py
+++ b/src/lightning_ml/learners/contrastive.py
@@ -14,13 +14,13 @@ __all__ = ["Contrastive"]
 class Contrastive(Learner):
     """Contrastive learning task. Supports both supervised and unsupervised."""
 
-    def batch_forward(self, batch: Dict[str, Any]) -> Any:
+    def batch_forward(self, batch: dict[str, Any]) -> Any:
         """Forward hook to underlying model `self.model`"""
         z1 = self.model(batch["input"])
         z2 = self.model(batch["positive"])
         return z1, z2
 
-    def compute_loss(self, model_outputs: Any, targets: Optional[Any] = None) -> Tensor:
+    def compute_loss(self, model_outputs: Any, targets: Any | None = None) -> Tensor:
         """Compute loss given raw ``model_outputs`` and ``targets``.
 
         Assumes loss fn takes input_embedding, positive_emedding, (label)

--- a/src/lightning_ml/learners/semi_supervised.py
+++ b/src/lightning_ml/learners/semi_supervised.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Callable
+from typing import Any, Dict, Optional
+from collections.abc import Callable
 
 from torch import Tensor
 
@@ -32,11 +33,11 @@ class SemiSupervised(Learner):
         self.unsupervised_criterion = unsupervised_criterion
         self.lambda_u = lambda_u
 
-    def batch_forward(self, batch: Dict[str, Any]) -> Any:
+    def batch_forward(self, batch: dict[str, Any]) -> Any:
         """Forward hook to underlying model ``self.model``"""
         return self.model(batch["input"])
 
-    def compute_loss(self, model_outputs: Any, targets: Optional[Any] = None) -> Tensor:
+    def compute_loss(self, model_outputs: Any, targets: Any | None = None) -> Tensor:
         """Compute weighted semi-supervised loss."""
         loss_u = self.unsupervised_criterion(model_outputs)
         loss_s = self.criterion(model_outputs, targets) if targets is not None else 0

--- a/src/lightning_ml/learners/supervised.py
+++ b/src/lightning_ml/learners/supervised.py
@@ -12,10 +12,10 @@ from ..core import Learner
 class Supervised(Learner):
     """Generic supervised learning task."""
 
-    def batch_forward(self, batch: Dict[str, Any]) -> Any:
+    def batch_forward(self, batch: dict[str, Any]) -> Any:
         """Forward hook to underlying model `self.model`"""
         return self.model(batch["input"])
 
-    def compute_loss(self, model_outputs: Any, targets: Optional[Any] = None) -> Tensor:
+    def compute_loss(self, model_outputs: Any, targets: Any | None = None) -> Tensor:
         """Compute loss given raw ``model_outputs`` and ``targets``."""
         return self.criterion(model_outputs, targets)

--- a/src/lightning_ml/learners/unsupervised.py
+++ b/src/lightning_ml/learners/unsupervised.py
@@ -12,10 +12,10 @@ from ..core import Learner
 class Unsupervised(Learner):
     """Generic unsupervised learning task."""
 
-    def batch_forward(self, batch: Dict[str, Any]) -> Any:
+    def batch_forward(self, batch: dict[str, Any]) -> Any:
         """Forward hook to underlying model `self.model`"""
         return self.model(batch["input"])
 
-    def compute_loss(self, model_outputs: Any, targets: Optional[Any] = None) -> Tensor:
+    def compute_loss(self, model_outputs: Any, targets: Any | None = None) -> Tensor:
         """Compute loss given raw ``model_outputs`` and ``targets``."""
         return self.criterion(model_outputs)

--- a/src/lightning_ml/predictors/classification.py
+++ b/src/lightning_ml/predictors/classification.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, List, Optional, Union
+from collections.abc import Sequence
 
 from torch import Tensor
 
@@ -25,7 +26,7 @@ class Classification(Predictor):
     def __init__(
         self,
         softmax: bool = True,
-        class_list: Optional[Sequence[str]] = None,
+        class_list: Sequence[str] | None = None,
         default_return: str = "indices",
     ) -> None:
         """Initialize the Classification predictor.
@@ -51,7 +52,7 @@ class Classification(Predictor):
             default_return = "indices"
         self.default_return = default_return
 
-    def _map_labels(self, o: Union[int, List[Any]]) -> Union[str, List[str]]:
+    def _map_labels(self, o: int | list[Any]) -> str | list[str]:
         """Recursively map class indices to labels.
 
         Args:
@@ -68,8 +69,8 @@ class Classification(Predictor):
         self,
         outputs: Tensor,
         *,
-        return_type: Optional[str] = None,
-    ) -> Union[Tensor, List[str]]:
+        return_type: str | None = None,
+    ) -> Tensor | list[str]:
         """Predict class indices, labels, or probabilities from model outputs.
 
         Args:

--- a/src/lightning_ml/utils/data.py
+++ b/src/lightning_ml/utils/data.py
@@ -5,7 +5,8 @@ This module provides a function to convert sklearn cross-validation splits
 into torch.utils.data.Subset objects for train and validation.
 """
 
-from typing import Dict, Iterator
+from typing import Dict
+from collections.abc import Iterator
 
 from sklearn.model_selection._split import BaseCrossValidator
 from torch.utils.data import Subset
@@ -15,7 +16,7 @@ from ..core import BaseDataset
 
 def validation_split(
     dataset: BaseDataset, cv: BaseCrossValidator
-) -> Iterator[Dict[str, Subset]]:
+) -> Iterator[dict[str, Subset]]:
     """Split a PyTorch Dataset into train and validation subsets.
 
     TODO: make support groups?

--- a/src/lightning_ml/utils/inspect.py
+++ b/src/lightning_ml/utils/inspect.py
@@ -7,7 +7,8 @@ import importlib
 import inspect
 from dataclasses import fields, is_dataclass
 from types import ModuleType
-from typing import Any, Callable, List, Type, Union
+from typing import Any, List, Type, Union
+from collections.abc import Callable
 
 __all__ = [
     "get_parent_classes",
@@ -23,7 +24,7 @@ __all__ = [
 
 
 # Private helper to DRY module loading
-def _load_module(module: Union[str, ModuleType]) -> ModuleType:
+def _load_module(module: str | ModuleType) -> ModuleType:
     """
     Load and return a module object from a module name or return if already a module.
     """
@@ -35,10 +36,10 @@ def _load_module(module: Union[str, ModuleType]) -> ModuleType:
 
 
 def get_parent_classes(
-    target: Union[Type[Any], Any],
-    module: Union[str, ModuleType],
+    target: type[Any] | Any,
+    module: str | ModuleType,
     recursive: bool = True,
-) -> List[Type[Any]]:
+) -> list[type[Any]]:
     """
     Return all base classes of `target` (a class or instance) that are defined in `module`.
 
@@ -69,8 +70,8 @@ def get_parent_classes(
 
 
 def get_child_classes(
-    base: Type[Any], module: Union[str, ModuleType]
-) -> List[Type[Any]]:
+    base: type[Any], module: str | ModuleType
+) -> list[type[Any]]:
     """
     Return all subclasses of `base` defined in `module`, excluding the base itself.
 
@@ -90,7 +91,7 @@ def get_child_classes(
     return subclasses
 
 
-def get_module_functions(module: Union[str, ModuleType]) -> List[Callable]:
+def get_module_functions(module: str | ModuleType) -> list[Callable]:
     """
     Return all top-level functions defined in `module`.
 
@@ -146,7 +147,7 @@ def get_summary(obj: Any) -> str:
     return doc.strip().split("\n", 1)[0]
 
 
-def ensure_has_attributes(obj: Any, attrs: List[str]) -> None:
+def ensure_has_attributes(obj: Any, attrs: list[str]) -> None:
     """
     Raise AttributeError if `obj` is missing any of the specified attribute names.
     """
@@ -155,7 +156,7 @@ def ensure_has_attributes(obj: Any, attrs: List[str]) -> None:
         raise AttributeError(f"{obj!r} is missing attributes: {missing}")
 
 
-def get_dataclass_fields(obj: Any) -> List[str]:
+def get_dataclass_fields(obj: Any) -> list[str]:
     """
     If `obj` is a dataclass or instance thereof, return its field names.
 
@@ -168,7 +169,7 @@ def get_dataclass_fields(obj: Any) -> List[str]:
     raise TypeError(f"{cls.__name__} is not a dataclass")
 
 
-def get_class_parameters(obj: Any) -> List[str]:
+def get_class_parameters(obj: Any) -> list[str]:
     """
     If `obj` is a class or instance thereof, return its parameter names.
     """

--- a/src/lightning_ml/utils/registry.py
+++ b/src/lightning_ml/utils/registry.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, List, Optional, TypeVar
+from typing import List, Optional, TypeVar
+from collections.abc import Callable
 
 T = TypeVar("T")
 
@@ -22,7 +23,7 @@ class Registry(dict):
         self._lib = lib
 
     # ------------------------------------------------------------------
-    def register(self, name: Optional[str] = None) -> Callable[[T], T]:
+    def register(self, name: str | None = None) -> Callable[[T], T]:
         """Decorator used to register ``cls`` under ``name``."""
 
         def decorator(cls: T) -> T:
@@ -41,7 +42,7 @@ class Registry(dict):
             raise KeyError(f"{self._lib} '{name}' not found in registry")
         return super().__getitem__(name)
 
-    def list_keys(self) -> List[str]:  # pragma: no cover - trivial
+    def list_keys(self) -> list[str]:  # pragma: no cover - trivial
         """Return a list of registered names."""
         return list(self.keys())
 

--- a/src/lightning_ml/utils/torchvision.py
+++ b/src/lightning_ml/utils/torchvision.py
@@ -21,7 +21,7 @@ def _import_torchvision():
         raise ImportError("torchvision is required for this functionality") from e
 
 
-def register_torchvision_models(registry: Optional[Registry] = None) -> None:
+def register_torchvision_models(registry: Registry | None = None) -> None:
     """Register all torchvision model functions and classes."""
     tv = _import_torchvision()
     from ..models import MODEL_REG  # local import to avoid circular dependency
@@ -45,7 +45,7 @@ def register_torchvision_models(registry: Optional[Registry] = None) -> None:
             pass
 
 
-def register_torchvision_datasets(registry: Optional[Registry] = None) -> None:
+def register_torchvision_datasets(registry: Registry | None = None) -> None:
     """Register all torchvision dataset classes."""
     tv = _import_torchvision()
     from ..datasets import DATASET_REG

--- a/src/lightning_ml/utils/utils.py
+++ b/src/lightning_ml/utils/utils.py
@@ -11,7 +11,7 @@ OutT = TypeVar("OutT", bound=type)
 __all__ = ["bind_classes"]
 
 
-def bind_classes(base_cls: Type[BaseT], mixin_cls: Type[MixinT], name: str | None = None) -> Type[OutT]:
+def bind_classes(base_cls: type[BaseT], mixin_cls: type[MixinT], name: str | None = None) -> type[OutT]:
     """Create a new class combining ``mixin_cls`` and ``base_cls``.
 
     Parameters


### PR DESCRIPTION
## Summary
- modernize type hints for Python 3.10+
- expose `TorchvisionDataset` at package level
- add fallback for `LightningEnum`
- drop unused imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c27e09f28832db3426a62045b95cc