### PR TITLE
Fix circular imports and expose datasets alias

### DIFF
--- a/src/lightning_ml/__init__.py
+++ b/src/lightning_ml/__init__.py
@@ -1,5 +1,8 @@
 """Lightning-ML core package."""
 
 from . import core, data, learners, models, predictors, utils
+# Re-export ``lightning_ml.data.datasets`` as ``lightning_ml.datasets`` for
+# convenience and to match the public API expected by the tests.
+from .data import datasets as datasets
 
-__all__ = ["core", "data", "learners", "models", "predictors", "utils"]
+__all__ = ["core", "data", "learners", "models", "predictors", "utils", "datasets"]

--- a/src/lightning_ml/data/datasets/__init__.py
+++ b/src/lightning_ml/data/datasets/__init__.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 from ...utils.registry import Registry
+
+# Define the registry before importing submodules that register with it to
+# avoid import cycles during package initialisation.
+DATASET_REG = Registry("Dataset")
+
+# Import dataset implementations which will register themselves with
+# ``DATASET_REG`` on import.
 from .abstract import *  # noqa: F401,F403
 from .contrastive import *  # noqa: F401,F403
 from .disk import *  # noqa: F401,F403
 from .labelled import *  # noqa: F401,F403
 from .unlabelled import *  # noqa: F401,F403
 from .wrappers import TorchvisionDataset
-
-DATASET_REG = Registry("Dataset")
 
 
 __all__ = [

--- a/src/lightning_ml/data/datasets/abstract.py
+++ b/src/lightning_ml/data/datasets/abstract.py
@@ -9,7 +9,10 @@ This module provides:
 from typing import Any
 from collections.abc import Sequence
 
-from ..core import BaseDataset
+# Import ``BaseDataset`` directly from the core package to avoid relying on a
+# non-existent ``data.core`` module and to prevent circular imports when the
+# top-level package is initialised.
+from lightning_ml.core.data.dataset import BaseDataset
 
 __all__ = [
     "InputMixin",

--- a/src/lightning_ml/datasets/__init__.py
+++ b/src/lightning_ml/datasets/__init__.py
@@ -1,0 +1,4 @@
+"""Alias module exposing dataset utilities at ``lightning_ml.datasets``."""
+
+from ..data.datasets import *
+

--- a/src/lightning_ml/utils/data.py
+++ b/src/lightning_ml/utils/data.py
@@ -11,7 +11,10 @@ from collections.abc import Iterator
 from sklearn.model_selection._split import BaseCrossValidator
 from torch.utils.data import Subset
 
-from ..core import BaseDataset
+# Avoid importing the entire ``lightning_ml.core`` package here to prevent
+# circular import issues when ``lightning_ml`` is imported.  Importing the
+# dataset module directly keeps dependencies minimal.
+from lightning_ml.core.data.dataset import BaseDataset
 
 
 def validation_split(


### PR DESCRIPTION
## Summary
- break circular imports by importing `BaseDataset` directly
- move dataset registry creation before importing dataset modules
- re-export dataset package from `lightning_ml` and add alias module
- add `lightning_ml.datasets` convenience package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c349e8cfc832db07afe4e5f4545e6