### PR TITLE
Convert to enum-based registries

### DIFF
--- a/src/lightning_ml/core/data/datasets/__init__.py
+++ b/src/lightning_ml/core/data/datasets/__init__.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from lightning_ml.core.utils.registry import Registry
+from lightning_ml.core.utils.enums import Registries
+from lightning_ml.core.utils.registry import get_registry
 
 # Define the registry before importing submodules that register with it to
 # avoid import cycles during package initialisation.
-DATASET_REG = Registry("Dataset")
+DATASET_REG = get_registry(Registries.DATASET)
 
 # Import dataset implementations which will register themselves with
 # ``DATASET_REG`` on import.

--- a/src/lightning_ml/core/data/datasets/contrastive.py
+++ b/src/lightning_ml/core/data/datasets/contrastive.py
@@ -11,7 +11,8 @@ import random
 from typing import Any, Optional
 from collections.abc import Callable, Sequence
 
-from . import DATASET_REG
+from ...utils.enums import Registries
+from ...utils.registry import register
 from .abstract import ContastiveDatasetBase, TripletDatasetBase
 from .labelled import LabelledDataset
 from .unlabelled import UnlabelledDataset
@@ -23,7 +24,7 @@ __all__ = [
 ]
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class ContrastiveLabelledDataset(LabelledDataset, ContastiveDatasetBase):
     """
     In-memory contrastive dataset for labelled data.
@@ -79,7 +80,7 @@ class ContrastiveLabelledDataset(LabelledDataset, ContastiveDatasetBase):
         return self.get_input(pos_idx)
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class ContrastiveUnlabelledDataset(UnlabelledDataset, ContastiveDatasetBase):
     """
     Contrastive dataset without labels.
@@ -118,7 +119,7 @@ class ContrastiveUnlabelledDataset(UnlabelledDataset, ContastiveDatasetBase):
         return self.get_input(idx)
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class TripletDataset(ContrastiveLabelledDataset, TripletDatasetBase):
     """
     Triplet dataset returning (anchor, positive, negative) given class labels.

--- a/src/lightning_ml/core/data/datasets/disk.py
+++ b/src/lightning_ml/core/data/datasets/disk.py
@@ -10,7 +10,8 @@ import numpy as np
 import pandas as pd
 from PIL import Image
 
-from . import DATASET_REG
+from ...utils.enums import Registries
+from ...utils.registry import register
 from .labelled import LabelledDataset
 from .unlabelled import UnlabelledDataset
 
@@ -22,7 +23,7 @@ __all__ = [
 ]
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class NumpyUnlabelledDataset(UnlabelledDataset):
     """Unlabelled dataset backed by a NumPy array or ``.npy`` file."""
 
@@ -37,7 +38,7 @@ class NumpyUnlabelledDataset(UnlabelledDataset):
         super().__init__(inputs, transform=transform)
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class NumpyLabelledDataset(LabelledDataset):
     """Labelled dataset backed by NumPy arrays or ``.npy`` files."""
 
@@ -61,7 +62,7 @@ class NumpyLabelledDataset(LabelledDataset):
         )
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class CSVDataset(LabelledDataset):
     """Labelled dataset loaded from a CSV file."""
 
@@ -83,7 +84,7 @@ class CSVDataset(LabelledDataset):
         )
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class ImageFolderDataset(LabelledDataset):
     """Simple image classification dataset from a folder structure."""
 

--- a/src/lightning_ml/core/data/datasets/unlabelled.py
+++ b/src/lightning_ml/core/data/datasets/unlabelled.py
@@ -8,13 +8,14 @@ input and target sequences.
 from typing import Any, Optional
 from collections.abc import Callable, Sequence
 
-from . import DATASET_REG
+from ...utils.enums import Registries
+from ...utils.registry import register
 from .abstract import UnlabelledDatasetBase
 
 __all__ = ["UnlabelledDataset"]
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class UnlabelledDataset(UnlabelledDatasetBase):
     """Generic labelled dataset with optional transforms.
 

--- a/src/lightning_ml/core/data/datasets/wrappers/torchvision.py
+++ b/src/lightning_ml/core/data/datasets/wrappers/torchvision.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Type
 
-from .. import DATASET_REG
+from ....utils.enums import Registries
+from ....utils.registry import register
 from ..abstract import LabelledDatasetBase
 
 __all__ = ["TorchvisionDataset"]
@@ -15,7 +16,7 @@ except Exception as e:  # pragma: no cover - import dependency
     raise ImportError("PyTorch is required for TorchvisionDataset") from e
 
 
-@DATASET_REG.register()
+@register(Registries.DATASET)
 class TorchvisionDataset(LabelledDatasetBase):
     """
     Wraps a torchvision dataset to adapt it to Lightning-ML's Dataset API.

--- a/src/lightning_ml/core/learners/__init__.py
+++ b/src/lightning_ml/core/learners/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from ..utils.registry import Registry
+from ..utils.enums import Registries
+from ..utils.registry import get_registry
 
-LEARNER_REG = Registry("Learner")
+LEARNER_REG = get_registry(Registries.LEARNER)
 
 from .contrastive import Contrastive  # noqa: F401
 from .supervised import Supervised  # noqa: F401

--- a/src/lightning_ml/core/learners/contrastive.py
+++ b/src/lightning_ml/core/learners/contrastive.py
@@ -4,13 +4,14 @@ from typing import Any, Dict, Optional
 
 from torch import Tensor
 
-from . import LEARNER_REG
+from ..utils.enums import Registries
+from ..utils.registry import register
 from ..core import Learner
 
 __all__ = ["Contrastive"]
 
 
-@LEARNER_REG.register()
+@register(Registries.LEARNER)
 class Contrastive(Learner):
     """Contrastive learning task. Supports both supervised and unsupervised."""
 

--- a/src/lightning_ml/core/learners/semi_supervised.py
+++ b/src/lightning_ml/core/learners/semi_supervised.py
@@ -7,13 +7,14 @@ from collections.abc import Callable
 
 from torch import Tensor
 
-from . import LEARNER_REG
+from ..utils.enums import Registries
+from ..utils.registry import register
 from ..core import Learner
 
 __all__ = ["SemiSupervised"]
 
 
-@LEARNER_REG.register()
+@register(Registries.LEARNER)
 class SemiSupervised(Learner):
     """Generic semi-supervised learning task.
 

--- a/src/lightning_ml/core/learners/supervised.py
+++ b/src/lightning_ml/core/learners/supervised.py
@@ -4,11 +4,12 @@ from typing import Any, Dict, Optional
 
 from torch import Tensor
 
-from . import LEARNER_REG
+from ..utils.enums import Registries
+from ..utils.registry import register
 from ..core import Learner
 
 
-@LEARNER_REG.register()
+@register(Registries.LEARNER)
 class Supervised(Learner):
     """Generic supervised learning task."""
 

--- a/src/lightning_ml/core/learners/unsupervised.py
+++ b/src/lightning_ml/core/learners/unsupervised.py
@@ -4,11 +4,12 @@ from typing import Any, Dict, Optional
 
 from torch import Tensor
 
-from . import LEARNER_REG
+from ..utils.enums import Registries
+from ..utils.registry import register
 from ..core import Learner
 
 
-@LEARNER_REG.register()
+@register(Registries.LEARNER)
 class Unsupervised(Learner):
     """Generic unsupervised learning task."""
 

--- a/src/lightning_ml/core/predictors/__init__.py
+++ b/src/lightning_ml/core/predictors/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from ..utils.registry import Registry
+from ..utils.enums import Registries
+from ..utils.registry import get_registry
 
-PREDICTOR_REG = Registry("Predictor")
+PREDICTOR_REG = get_registry(Registries.PREDICTOR)
 
 from .classification import *  # noqa: F401,F403
 from .regression import *  # noqa: F401,F403

--- a/src/lightning_ml/core/predictors/classification.py
+++ b/src/lightning_ml/core/predictors/classification.py
@@ -8,13 +8,14 @@ from collections.abc import Sequence
 
 from torch import Tensor
 
+from ..utils.enums import Registries
+from ..utils.registry import register
 from ..core import Predictor
-from . import PREDICTOR_REG
 
 __all__ = ["Classification"]
 
 
-@PREDICTOR_REG.register()
+@register(Registries.PREDICTOR)
 class Classification(Predictor):
     """Predictor for classification tasks.
 

--- a/src/lightning_ml/core/predictors/regression.py
+++ b/src/lightning_ml/core/predictors/regression.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from torch import Tensor
 
-from . import PREDICTOR_REG
+from ..utils.enums import Registries
+from ..utils.registry import register
 from ..core import Predictor
 
 __all__ = ["Regression"]
 
 
-@PREDICTOR_REG.register()
+@register(Registries.PREDICTOR)
 class Regression(Predictor):
     """Return regression outputs as 1D tensors."""
 

--- a/src/lightning_ml/core/utils/enums.py
+++ b/src/lightning_ml/core/utils/enums.py
@@ -1,4 +1,11 @@
-from pytorch_lightning.utilities.enums import LightningEnum
+try:  # pragma: no cover - dependency check
+    from pytorch_lightning.utilities.enums import LightningEnum
+except Exception:  # pragma: no cover - fallback when lightning not installed
+    from enum import Enum
+
+    class LightningEnum(str, Enum):
+        """Minimal fallback for :class:`pytorch_lightning.utilities.enums.LightningEnum`."""
+        pass
 
 
 class DataKeys(LightningEnum):

--- a/src/lightning_ml/models/__init__.py
+++ b/src/lightning_ml/models/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from ..core.utils.registry import Registry
+from ..core.utils.enums import Registries
+from ..core.utils.registry import get_registry
 
-MODEL_REG = Registry("Model")
+MODEL_REG = get_registry(Registries.MODEL)
 
 from .example import *  # noqa: F401,F403
 

--- a/src/lightning_ml/models/example.py
+++ b/src/lightning_ml/models/example.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import torch.nn as nn
 
-from . import MODEL_REG
+from ..core.utils.enums import Registries
+from ..core.utils.registry import register
 
 __all__ = ["MyCustomModel"]
 
 
-@MODEL_REG.register("MyCustomModel")
+@register(Registries.MODEL, "MyCustomModel")
 class MyCustomModel(nn.Module):
     """Simple fully connected network used as an example."""
 

--- a/src/lightning_ml/utils/__init__.py
+++ b/src/lightning_ml/utils/__init__.py
@@ -1,3 +1,2 @@
 from . import data, inspect, torchvision
-from ..core.utils.registry import Registry
 from .utils import *


### PR DESCRIPTION
## Summary
- register learners, predictors, models and datasets using the new `register` decorator
- expose registries via `get_registry` helper
- provide LightningEnum fallback when PyTorch Lightning isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1be7f380832d92c9d5e044680d9a