### PR TITLE
Modular registry initialisation

### DIFF
--- a/src/lightning_ml/__init__.py
+++ b/src/lightning_ml/__init__.py
@@ -1,0 +1,22 @@
+"""Lightning-ML top-level package.
+
+Importing :mod:`lightning_ml` initialises the core registries so the base
+components are always registered.  Modality packages (e.g.
+:mod:`lightning_ml.vision`) register their components only when imported.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+# Import modules that create the core registries and register their built-in
+# components.  Import order doesn't matter as each registry is independent.
+import_module("lightning_ml.core.data.datasets")
+try:
+    import_module("lightning_ml.core.data.loaders")
+except Exception:  # pragma: no cover - optional deps may be missing
+    pass
+import_module("lightning_ml.core.learners")
+import_module("lightning_ml.core.predictors")
+
+__all__: list[str] = []

--- a/src/lightning_ml/core/abstract/loader.py
+++ b/src/lightning_ml/core/abstract/loader.py
@@ -6,7 +6,10 @@ from typing import Any, Sequence
 
 from lightning_ml.core.data.dataset import BaseDataset
 
-from .datasets import LabelledDataset, UnlabelledDataset
+# Dataset implementations live in the data package but `BaseLoader` is located
+# under ``core.abstract``. Import directly from the public data package to avoid
+# circular dependencies and to keep this module self contained.
+from lightning_ml.core.data.datasets import LabelledDataset, UnlabelledDataset
 
 
 @dataclass

--- a/src/lightning_ml/core/data/dataset.py
+++ b/src/lightning_ml/core/data/dataset.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper forwarding to :mod:`lightning_ml.core.abstract.dataset`."""
+
+from ..abstract.dataset import *  # noqa: F401,F403

--- a/src/lightning_ml/core/data/datasets/__init__.py
+++ b/src/lightning_ml/core/data/datasets/__init__.py
@@ -14,3 +14,4 @@ REGISTRY = get_registry(Registries.DATASET)
 from .contrastive import *  # noqa: F401,F403
 from .labelled import *  # noqa: F401,F403
 from .unlabelled import *  # noqa: F401,F403
+from .numpy import *  # noqa: F401,F403

--- a/src/lightning_ml/core/data/datasets/numpy.py
+++ b/src/lightning_ml/core/data/datasets/numpy.py
@@ -1,0 +1,44 @@
+"""Datasets backed by NumPy arrays or ``.npy`` files."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy as np
+
+from ...utils.enums import Registries
+from ...utils.registry import register
+from .labelled import LabelledDataset
+from .unlabelled import UnlabelledDataset
+
+__all__ = ["NumpyUnlabelledDataset", "NumpyLabelledDataset"]
+
+
+@register(Registries.DATASET)
+class NumpyUnlabelledDataset(UnlabelledDataset):
+    """Unlabelled dataset backed by a NumPy array or ``.npy`` file."""
+
+    def __init__(self, inputs: str | Sequence[Any] | np.ndarray, *, transform: Callable[[Any], Any] | None = None) -> None:
+        if isinstance(inputs, str):
+            inputs = np.load(inputs)
+        super().__init__(inputs, transform=transform)
+
+
+@register(Registries.DATASET)
+class NumpyLabelledDataset(LabelledDataset):
+    """Labelled dataset backed by NumPy arrays or ``.npy`` files."""
+
+    def __init__(
+        self,
+        inputs: str | Sequence[Any] | np.ndarray,
+        targets: str | Sequence[Any] | np.ndarray,
+        *,
+        transform: Callable[[Any], Any] | None = None,
+        target_transform: Callable[[Any], Any] | None = None,
+    ) -> None:
+        if isinstance(inputs, str):
+            inputs = np.load(inputs)
+        if isinstance(targets, str):
+            targets = np.load(targets)
+        super().__init__(inputs, targets, transform=transform, target_transform=target_transform)

--- a/src/lightning_ml/core/data/loader.py
+++ b/src/lightning_ml/core/data/loader.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper forwarding to :mod:`lightning_ml.core.abstract.loader`."""
+
+from ..abstract.loader import *  # noqa: F401,F403

--- a/src/lightning_ml/core/data/sample.py
+++ b/src/lightning_ml/core/data/sample.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper forwarding to :mod:`lightning_ml.core.abstract.sample`."""
+
+from ..abstract.sample import *  # noqa: F401,F403

--- a/src/lightning_ml/vision/__init__.py
+++ b/src/lightning_ml/vision/__init__.py
@@ -1,0 +1,24 @@
+"""Vision modality package.
+
+Importing this subpackage registers vision-specific components such as
+Torchvision models and datasets if the dependency is available.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+try:
+    from ..utils.torchvision import register_torchvision
+
+    register_torchvision()
+except Exception:
+    # torchvision not installed; silently skip registration
+    pass
+
+# Import submodules so any @register decorators run on import.
+import_module("lightning_ml.vision.loaders")
+import_module("lightning_ml.vision.classification.data.loaders")
+import_module("lightning_ml.vision.detection.data.loaders")
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- ensure dataset base classes are available again via compatibility wrappers
- add numpy dataset implementations
- initialise core registries when the package is imported
- register vision-specific modules on demand
- fix BaseLoader import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d36f3c6c8832d969b2dff247b9a80