### PR TITLE
Fix hydra config warnings and expose registries

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -1,4 +1,5 @@
 defaults:
+  - _self_
   - dataset: labelled
   - model: resnet
 

--- a/main.py
+++ b/main.py
@@ -9,10 +9,10 @@ from omegaconf import DictConfig
 from lightning_ml.core.utils.config import Config
 
 cs = ConfigStore.instance()
-cs.store(name="config", node=Config)
+cs.store(name="app_config", node=Config)
 
 
-@hydra.main(config_name="config", config_path="cfg")
+@hydra.main(version_base="1.1", config_name="config", config_path="cfg")
 def main(cfg: Config) -> None:
     """Entry point for application."""
     print(f"Running with seed={cfg.seed}")

--- a/src/lightning_ml/core/utils/registry.py
+++ b/src/lightning_ml/core/utils/registry.py
@@ -6,6 +6,8 @@ from typing import Any, Callable, TypeVar
 
 from .enums import Registries
 from .imports import import_from_str
+from pathlib import Path
+from typing import Any
 
 __all__ = [
     "Registry",
@@ -243,3 +245,10 @@ def build_from_cfg(kind: Any, name: str, *args, **kwargs):
     """
     params = kwargs.get("params", {})
     return build(kind, name, *args, **params)
+
+
+def instantiate_from_yaml(cfg_path: str | Path) -> Any:
+    """Instantiate an object from a YAML config file."""
+    from .config import instantiate_from_yaml as _impl
+
+    return _impl(cfg_path)

--- a/src/lightning_ml/datasets/__init__.py
+++ b/src/lightning_ml/datasets/__init__.py
@@ -1,0 +1,12 @@
+"""Dataset registry and built-in datasets."""
+
+from __future__ import annotations
+
+from ..core.utils.enums import Registries
+from ..core.utils.registry import get_registry
+from ..core.data.datasets import *  # noqa: F401,F403
+from ..core.data.datasets.wrappers import TorchvisionDataset  # noqa: F401
+
+DATASET_REG = get_registry(Registries.DATASET)
+
+__all__ = ["DATASET_REG"]

--- a/src/lightning_ml/models/__init__.py
+++ b/src/lightning_ml/models/__init__.py
@@ -1,0 +1,10 @@
+"""Model registry and built-in models."""
+
+from __future__ import annotations
+
+from ..core.utils.enums import Registries
+from ..core.utils.registry import get_registry
+
+MODEL_REG = get_registry(Registries.MODEL)
+
+__all__ = ["MODEL_REG"]


### PR DESCRIPTION
## Summary
- silence Hydra deprecation warnings
- expose dataset/model registries so the tests can import them
- re-export `instantiate_from_yaml` lazily to avoid dependency errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffefeaffc832db66c8b062538d07f