### PR TITLE
Add Hydra integration with registry-based configs

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,7 +1,8 @@
 # Root config ties everything together and sets defaults
 defaults:
-  - dataset: labelled
-  - loader: imagefolder
+  - data/dataset: labelled
+  - data/loader: imagefolder
+  - _self_
   # - model: resnet50
   # - optimizer: adam
 

--- a/conf/data/dataset/labelled.yaml
+++ b/conf/data/dataset/labelled.yaml
@@ -1,0 +1,4 @@
+name: LabelledDataset
+params:
+  inputs: [1, 2]
+  targets: [3, 4]

--- a/conf/data/loader/imagefolder.yaml
+++ b/conf/data/loader/imagefolder.yaml
@@ -1,0 +1,3 @@
+name: ImageFolder
+params:
+  root: "."

--- a/conf/dataset/labelled.yaml
+++ b/conf/dataset/labelled.yaml
@@ -1,1 +1,0 @@
-name: LabelledDataset

--- a/main.py
+++ b/main.py
@@ -1,53 +1,18 @@
-# # main.py
-# import sys
-
-# sys.path.append("src")
-# import hydra
-# from hydra.core.config_store import ConfigStore
-# from omegaconf import DictConfig
-
-# from lightning_ml.core.utils.config import Config
-
-# cs = ConfigStore.instance()
-# cs.store(name="app_config", node=Config)
-
-
-# @hydra.main(version_base="1.1", config_name="config", config_path="cfg")
-# def main(cfg: Config) -> None:
-#     """Entry point for application."""
-#     print(f"Running with seed={cfg.seed}")
-#     print(f"Model: {cfg.model.name}")
-
-
-# if __name__ == "__main__":
-#     main()
-
-
-# main.py
-import sys
-
 import hydra
 from hydra.core.config_store import ConfigStore
 
 from lightning_ml.core.utils.config import Config
-from lightning_ml.core.utils.enums import Registries
-
-sys.path.append("src")
-
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=Config)
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(config_path="conf", config_name="config", version_base=None)
 def main(cfg: Config) -> None:
-    # instantiate data components
-    data_components = cfg.data.instantiate()
-    loader = data_components["loader"]
-    dataset = data_components["dataset"]
-    # instantiate model and optimizer
-    print(loader)
-    print(cfg.optimizer)
+    components = cfg.instantiate()
+    dataset = components["data"]
+    print(f"Loaded dataset: {type(dataset).__name__}, length={len(dataset)}")
+    print(f"Seed: {cfg.seed}")
 
 
 if __name__ == "__main__":

--- a/src/lightning_ml/core/data/loaders/csv.py
+++ b/src/lightning_ml/core/data/loaders/csv.py
@@ -3,8 +3,11 @@ from typing import Any, Dict, Optional, Sequence
 
 from lightning_ml.core.abstract.loader import BaseLoader
 from lightning_ml.core.utils.imports import requires
+from lightning_ml.core.utils.enums import Registries
+from lightning_ml.core.utils.registry import register
 
 
+@register(Registries.LOADER)
 @requires("pandas")
 @dataclass
 class CSVLoader(BaseLoader):

--- a/src/lightning_ml/core/data/loaders/folder.py
+++ b/src/lightning_ml/core/data/loaders/folder.py
@@ -5,8 +5,11 @@ from typing import Any, Optional
 
 from lightning_ml.core.abstract.loader import BaseLoader
 from lightning_ml.core.utils.loading import has_file_allowed_extension
+from lightning_ml.core.utils.enums import Registries
+from lightning_ml.core.utils.registry import register
 
 
+@register(Registries.LOADER)
 class Folder(BaseLoader):
     """
     Folder data loader.

--- a/src/lightning_ml/core/utils/registry.py
+++ b/src/lightning_ml/core/utils/registry.py
@@ -303,7 +303,19 @@ def build(kind: Any, name: str, *args, **kwargs):
 #         >>> obj.shape
 #         (3, 2)
 #     """
-#     config = config.to_dict()
-#     name = config.get("name")
-#     params = config.get("params", {})
-#     return build(kind, name, **params)
+
+
+def build_from_cfg(kind: Any, name: str, params: dict | None = None) -> Any:
+    """Instantiate a registered object from a configuration mapping."""
+
+    return build(kind, name, **(params or {}))
+
+
+def instantiate_from_yaml(cfg_path: str | Path) -> Any:
+    """Load a Hydra YAML config and instantiate the described object."""
+
+    from hydra.utils import instantiate
+    from omegaconf import OmegaConf
+
+    cfg = OmegaConf.load(str(cfg_path))
+    return instantiate(cfg)

--- a/src/lightning_ml/vision/classification/data/loaders.py
+++ b/src/lightning_ml/vision/classification/data/loaders.py
@@ -8,8 +8,11 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ...loaders import ImageFolder
+from lightning_ml.core.utils.enums import Registries
+from lightning_ml.core.utils.registry import register
 
 
+@register(Registries.LOADER)
 class ImageClassificationFolder(ImageFolder):
     """Loads all images from specified folder"""
 

--- a/src/lightning_ml/vision/detection/data/loaders.py
+++ b/src/lightning_ml/vision/detection/data/loaders.py
@@ -12,6 +12,8 @@ from lightning_ml.core.utils.loading import (
 )
 
 from ..loaders import ImageFolder  # ← your current class
+from lightning_ml.core.utils.enums import Registries
+from lightning_ml.core.utils.registry import register
 
 
 # ─────────────────────────────────────────────────────────────
@@ -45,6 +47,7 @@ def _parse_yolo_label_file(path: Path) -> list[dict[str, float]]:
 # ─────────────────────────────────────────────────────────────
 # Loader
 # ─────────────────────────────────────────────────────────────
+@register(Registries.LOADER)
 class YOLOFolder(ImageFolder):
     """YOLO directory-tree loader.
 

--- a/src/lightning_ml/vision/loaders.py
+++ b/src/lightning_ml/vision/loaders.py
@@ -11,12 +11,15 @@ from typing import Any, Optional, Sequence
 from lightning_ml.core.abstract.loader import BaseLoader
 from lightning_ml.core.data.loaders.folder import Folder
 from lightning_ml.core.utils.loading import IMG_EXTENSIONS, load_image
+from lightning_ml.core.utils.enums import Registries
+from lightning_ml.core.utils.registry import register
 
 # def subdirs_as_classes(directory: str | Path) -> list[str]:
 #     """Finds the class folders in a dataset. Assumes first=layer subdirs."""
 #     return sorted(entry.name for entry in os.scandir(directory) if entry.is_dir())
 
 
+@register(Registries.LOADER)
 class ImageFiles(BaseLoader):
     """Loads images from filepaths"""
 
@@ -32,6 +35,7 @@ class ImageFiles(BaseLoader):
         return [load_image(f) for f in self.file_paths]
 
 
+@register(Registries.LOADER)
 class ImageFolder(Folder):
     """Loads all images from specified folder"""
 


### PR DESCRIPTION
## Summary
- implement dataclass based config system
- hook Hydra into the project entrypoint
- expose helpers to instantiate from YAML configs
- register available loaders
- provide example Hydra configs under `conf/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866543bbb8832d9bd5fe96170c14b9